### PR TITLE
unquote queryStringParameters

### DIFF
--- a/flask_lambda.py
+++ b/flask_lambda.py
@@ -21,6 +21,11 @@ try:
 except ImportError:
     from urllib.parse import urlencode
 
+try:
+    from urllib import unquote
+except ImportError:
+    from urllib.parse import unquote
+
 from flask import Flask
 
 try:
@@ -33,8 +38,7 @@ except ImportError:
 
 from werkzeug.wrappers import BaseRequest
 
-
-__version__ = '0.0.4'
+__version__ = '0.0.5'
 
 
 def make_environ(event):
@@ -52,6 +56,9 @@ def make_environ(event):
         environ[http_hdr_name] = hdr_value
 
     qs = event['queryStringParameters']
+
+    for k, v in qs.items():
+        qs[k] = unquote(v)
 
     environ['REQUEST_METHOD'] = event['httpMethod']
     environ['PATH_INFO'] = event['path']


### PR DESCRIPTION
Added a quick loop to unquote values in the queryStringParameters dictionary. Previously spaces were inserted as %20 and needed to be sterilized.

EX: 
{'industry_filter': 'food%20services', 'limit': '10', 'order': 'desc', 'orderby': 'total_noncompliant_amount', 'page': '0'}
vs
{'industry_filter': 'food services', 'limit': '10', 'order': 'desc', 'orderby': 'total_noncompliant_amount', 'page': '0'}